### PR TITLE
Updating the _get_authors() function

### DIFF
--- a/arxivscraper/arxivscraper.py
+++ b/arxivscraper/arxivscraper.py
@@ -58,7 +58,7 @@ class Record(object):
             return "n/a"
 
     def _get_authors(self):
-        authors_xml = self.xml.findall(ARXIV + 'authors/' + ARXIV + 'author')
+        authors_xml = self.xml.findall('./metadata/*/' + ARXIV + 'authors/' + ARXIV + 'author')
         last_names = [self._get_name(author, 'keyname') for author in authors_xml]
         first_names = [self._get_name(author, 'forenames') for author in authors_xml]
         full_names = [a+' '+b for a,b in zip(first_names, last_names)]


### PR DESCRIPTION
While searching for the 'author' tag in the XML file, the findall function was not being able to find it because the **'author' tag isn't a direct child of the 'Record' tag** as part of the Tree structure of the XML file. Hence, the findall function returns an empty list for the variable 'authors_xml' which leads to **an attribute error** while trying to get the first and last names of authors. The proposed change modifies the input of the findall function to ensure that it searches the relevant structure of the XML tree for the 'author' tag.